### PR TITLE
fix: SPA遷移の速度改善・テーマフラッシュ解消・アニメーション最適化

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,7 +10,7 @@ export default defineConfig({
   trailingSlash: "always",
   prefetch: {
     prefetchAll: true,
-    defaultStrategy: "tap",
+    defaultStrategy: "hover",
   },
   markdown: {
     rehypePlugins: [

--- a/src/components/ThemeInit.astro
+++ b/src/components/ThemeInit.astro
@@ -9,5 +9,14 @@
     } catch {
       // Keep the default light theme if localStorage is unavailable.
     }
+
+    // Preserve theme across View Transitions — copy to new document before swap
+    // to prevent the flash caused by the new (statically-rendered) page resetting
+    // the dark class on <html>.
+    document.addEventListener("astro:before-swap", (event) => {
+      const theme = document.documentElement.dataset.theme ?? "light";
+      event.newDocument.documentElement.classList.toggle("dark", theme === "dark");
+      event.newDocument.documentElement.dataset.theme = theme;
+    });
   })();
 </script>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -67,7 +67,11 @@ const t = getUi(locale);
     // Run on initial load
     init();
 
-    // Re-run on View Transitions (if used)
-    document.addEventListener("astro:after-swap", init);
+    // Re-run on View Transitions — guard prevents duplicate listeners from accumulating
+    // across navigations because this inline script re-executes on every page swap.
+    if (!window.__themeToggleListenerAdded) {
+      window.__themeToggleListenerAdded = true;
+      document.addEventListener("astro:after-swap", init);
+    }
   })();
 </script>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -210,10 +210,35 @@ img {
   gap: 1.4rem;
 }
 
+/* Named view-transition layers — header/footer stay put, only main content moves */
+.site-header { view-transition-name: site-header; }
+.site-main   { view-transition-name: site-main;   }
+.site-footer { view-transition-name: site-footer; }
+
+/* Root (background layer) and chrome: instant swap, no crossfade */
 ::view-transition-old(root),
-::view-transition-new(root) {
-  animation-duration: 120ms;
-  animation-timing-function: ease-out;
+::view-transition-new(root),
+::view-transition-old(site-header),
+::view-transition-new(site-header),
+::view-transition-old(site-footer),
+::view-transition-new(site-footer) {
+  animation: none;
+  mix-blend-mode: normal;
+}
+
+/* Main content: slide-up entrance / slide-up exit */
+@keyframes vt-fade-out {
+  to { opacity: 0; transform: translateY(-6px); }
+}
+@keyframes vt-fade-in {
+  from { opacity: 0; transform: translateY(10px); }
+}
+
+::view-transition-old(site-main) {
+  animation: 120ms ease-in forwards vt-fade-out;
+}
+::view-transition-new(site-main) {
+  animation: 200ms ease-out forwards vt-fade-in;
 }
 
 @media (max-width: 760px) {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -211,9 +211,15 @@ img {
 }
 
 /* Named view-transition layers — header/footer stay put, only main content moves */
-.site-header { view-transition-name: site-header; }
-.site-main   { view-transition-name: site-main;   }
-.site-footer { view-transition-name: site-footer; }
+.site-header {
+  view-transition-name: site-header;
+}
+.site-main {
+  view-transition-name: site-main;
+}
+.site-footer {
+  view-transition-name: site-footer;
+}
 
 /* Root (background layer) and chrome: instant swap, no crossfade */
 ::view-transition-old(root),
@@ -228,10 +234,16 @@ img {
 
 /* Main content: slide-up entrance / slide-up exit */
 @keyframes vt-fade-out {
-  to { opacity: 0; transform: translateY(-6px); }
+  to {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
 }
 @keyframes vt-fade-in {
-  from { opacity: 0; transform: translateY(10px); }
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
 }
 
 ::view-transition-old(site-main) {


### PR DESCRIPTION
## Summary

- **テーマフラッシュ解消**: `astro:before-swap` で現在のテーマを新ドキュメントへ事前コピーし、静的HTMLの `dark` クラスリセットによる一瞬の白フラッシュを根本解消
- **体感速度の改善**: prefetch の `defaultStrategy` を `tap` → `hover` に変更し、ホバー時点でプリフェッチ開始。クリック時には既にキャッシュ済みになりほぼ遅延なしでナビゲート可能
- **SPA らしいアニメーション**: `view-transition-name` でヘッダー/フッターを非アニメーション化し、コンテンツ領域（`site-main`）のみスライドイン/アウトするSPA本来の体験を実現
- **リスナー重複バグ修正**: `is:inline` スクリプトはページ遷移ごとに再実行されるため `astro:after-swap` リスナーが蓄積する問題を `window.__themeToggleListenerAdded` フラグで防止

## Test plan

- [ ] ダークモードでページ遷移してもテーマが維持されること
- [ ] ライトモードでも同様に維持されること
- [ ] ヘッダー/フッターがページ遷移中に動かないこと（コンテンツだけスライド）
- [ ] リンクをホバーすると次のページがプリフェッチされること（Network タブで確認）
- [ ] テーマ切り替えボタンが遷移後も正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)