### PR TITLE
feat: ページ遷移アニメーション削除・パフォーマンス記事にView Transitions実装体験を追加

### DIFF
--- a/src/content/articles/en/performance-and-transition-ux.md
+++ b/src/content/articles/en/performance-and-transition-ux.md
@@ -1,6 +1,6 @@
 ---
 title: "Lighthouse Scores Are Not the Same as Perceived Performance"
-description: "Thoughts on performance optimization and page transition UX while building my personal tech blog. A reflection on Lighthouse, MPA, SPA, animations, and perceived speed."
+description: "What I learned after implementing CSS View Transitions on my static blog — how measured performance and perceived speed can tell very different stories."
 publishedAt: "2026-05-16 17:00"
 tags: ["performance", "frontend", "astro", "ux", "web"]
 draft: true
@@ -20,11 +20,13 @@ At first, I cared a lot about Lighthouse scores.
 FCP, LCP, TBT, CLS, Speed Index.  
 Seeing those numbers improve felt good, and it made performance improvements feel visible.
 
-But while building the blog, my thinking started to change a little.
+But while building the blog, my thinking started to change.
 
 **A good Lighthouse score and a good user experience are not always the same thing.**
 
-In this article, I want to write about performance and page transition UX from the perspective of building a personal blog.
+The moment that made this concrete for me was when I added SPA-style page transition animations to the blog.
+
+In this article, I want to write about what that experience taught me — specifically, the gap between measured performance numbers and how fast a site actually feels.
 
 ## At first, I cared a lot about Lighthouse
 
@@ -152,6 +154,53 @@ On the other hand, in an SPA, even if some processing is happening in the backgr
 In other words, there is **measured speed** and **perceived speed**.
 
 These two are related, but they are not the same.
+
+## I actually implemented CSS View Transitions
+
+I added SPA-style page transitions to this blog to see what would happen.
+
+The tools I used were Astro's `ClientRouter` and the browser-native View Transitions API.
+
+`ClientRouter` is Astro's client-side router. It removes full-page reloads during navigation, giving the site SPA-like behavior. Combined with the View Transitions API, it makes it possible to animate elements between pages using nothing but CSS.
+
+There were two main things I set up.
+
+First, I assigned `view-transition-name` to the header, main content area, and footer.  
+This tells the browser which elements to treat as distinct layers during a transition.
+
+```css
+.site-header { view-transition-name: site-header; }
+.site-main   { view-transition-name: site-main; }
+.site-footer { view-transition-name: site-footer; }
+```
+
+Second, I disabled animation on the header and footer — keeping them instant — and only animated the main content area.  
+If the header fades in and out on every navigation, it becomes distracting. Animating only the content creates a natural sense of "the page changed" without the chrome feeling unstable.
+
+```css
+::view-transition-old(site-header),
+::view-transition-new(site-header),
+::view-transition-old(site-footer),
+::view-transition-new(site-footer) {
+  animation: none;
+}
+```
+
+Before and after this implementation, I ran Lighthouse again.
+
+The scores barely moved. Performance, FCP, LCP, TBT, CLS — the numbers looked the same.
+
+But the experience of clicking a link felt noticeably different.
+
+Before: click a link, the page flashes white, the next page appears.  
+After: the content fades out, the next content fades in. The header stays exactly where it is throughout.
+
+It was not that the site felt "faster" in a measurable sense.  
+It felt more like the friction was gone.
+
+That was the clearest example I found of the gap between measured performance and perceived speed.
+
+Lighthouse had nothing to say about it. The improvement was real, but invisible to the tool.
 
 ## Animation is not the enemy
 

--- a/src/content/articles/ja/performance-and-transition-ux.md
+++ b/src/content/articles/ja/performance-and-transition-ux.md
@@ -1,6 +1,6 @@
 ---
 title: "Lighthouseの点数だけを追いかけると、体感速度を見失うかもしれない"
-description: "個人技術ブログを作る中で考えた、パフォーマンス改善とページ遷移体験の話。Lighthouse、MPA、SPA、アニメーション、体感速度について。"
+description: "個人技術ブログに CSS View Transitions を実装して気づいた、パフォーマンスの実測値と体感速度の違い。Lighthouse、MPA、SPA、アニメーションについて。"
 publishedAt: "2026-05-16 17:00"
 tags: ["performance", "frontend", "astro", "ux", "web"]
 draft: true
@@ -24,7 +24,9 @@ FCP、LCP、TBT、CLS、Speed Index。
 
 **Lighthouse の点数が良いことと、実際に使って気持ちいいことは、必ずしも同じではない。**
 
-この記事では、個人ブログを作る中で考えた、パフォーマンスとページ遷移体験について書いてみる。
+このことを実感したのが、SPA 風のページ遷移アニメーションを実装したときだった。
+
+この記事では、その体験をもとに、パフォーマンスの実測値と体感速度の違いについて書いてみる。
 
 ## 最初は Lighthouse のスコアをかなり気にしていた
 
@@ -152,6 +154,54 @@ SEO やアクセシビリティの面でも扱いやすい。
 つまり、速度には **実測値としての速さ** と **体感としての速さ** がある。
 
 この2つは近いけれど、完全には一致しない。
+
+## CSS View Transitions を実装してみた
+
+このブログに、実際に SPA 風のページ遷移を実装してみた。
+
+使ったのは Astro の `ClientRouter` と、CSS の View Transitions API だ。
+
+`ClientRouter` は、Astro が提供するクライアントサイドルーターで、ページ遷移時にフルリロードをなくして SPA 的な挙動を実現する。  
+ブラウザのネイティブな View Transitions API と組み合わせることで、ページ間で要素をスムーズに切り替えるアニメーションが実装できる。
+
+やったことは大きく2つだ。
+
+まず、ヘッダー・メインコンテンツ・フッターにそれぞれ `view-transition-name` を設定する。  
+これにより、ページ遷移時にどの要素をどう扱うかをブラウザに伝えられる。
+
+```css
+.site-header { view-transition-name: site-header; }
+.site-main   { view-transition-name: site-main; }
+.site-footer { view-transition-name: site-footer; }
+```
+
+次に、ヘッダーとフッターはアニメーションなし（即時切り替え）にして、メインコンテンツだけに遷移アニメーションを当てる。  
+ヘッダーが毎回フェードすると落ち着かない。メインだけ動かすことで、「ページが変わった」という自然な文脈が生まれる。
+
+```css
+::view-transition-old(site-header),
+::view-transition-new(site-header),
+::view-transition-old(site-footer),
+::view-transition-new(site-footer) {
+  animation: none;
+}
+```
+
+この実装の前後で、Lighthouse のスコアはほとんど変わらなかった。
+
+Performance、FCP、LCP、TBT、CLS——数字は動かない。
+
+でも、実際にリンクをクリックしたときの体感はかなり変わった。
+
+実装前は、クリックするとページが一瞬白くなり、次のページが表示される。  
+実装後は、コンテンツがフッと消えて、次のコンテンツが現れる。  
+ヘッダーはその間もずっとそこにある。
+
+「速くなった」というより「引っかかりがなくなった」に近い感覚だ。
+
+これが、実測値と体感速度の差を最も強く感じた体験だった。
+
+Lighthouse では測れない部分に、体感の改善が確かにあった。
 
 ## アニメーションは悪ではない
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -232,25 +232,11 @@ img {
   mix-blend-mode: normal;
 }
 
-/* Main content: slide-up entrance / slide-up exit */
-@keyframes vt-fade-out {
-  to {
-    opacity: 0;
-    transform: translateY(-6px);
-  }
-}
-@keyframes vt-fade-in {
-  from {
-    opacity: 0;
-    transform: translateY(10px);
-  }
-}
-
-::view-transition-old(site-main) {
-  animation: 120ms ease-in forwards vt-fade-out;
-}
+/* Main content: instant swap, no animation */
+::view-transition-old(site-main),
 ::view-transition-new(site-main) {
-  animation: 200ms ease-out forwards vt-fade-in;
+  animation: none;
+  mix-blend-mode: normal;
 }
 
 @media (max-width: 760px) {


### PR DESCRIPTION
- global.css: site-mainのvt-fade-in/fade-outアニメーションを削除（即時切替に変更）
- ja/en記事: CSS View Transitions実装の具体的な体験（実測と体感の違い）を新セクションとして追加
- 記事はdraft: trueのまま