### PR TITLE
feat: Shikiシンタックスハイライト導入

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -13,6 +13,14 @@ export default defineConfig({
     defaultStrategy: "hover",
   },
   markdown: {
+    shikiConfig: {
+      themes: {
+        light: "github-light",
+        dark: "github-dark",
+      },
+      defaultColor: "light",
+      wrap: false,
+    },
     rehypePlugins: [
       () => async (tree) => {
         const ogCache = new Map();

--- a/src/layouts/ArticleLayout.astro
+++ b/src/layouts/ArticleLayout.astro
@@ -388,7 +388,23 @@ const articleUrl = `${siteConfig.url}${canonicalPath}`;
     font-size: 0.92em;
   }
 
-  .article-content :global(pre) {
+  .article-content :global(pre.astro-code) {
+    border: 1px solid var(--color-border);
+    border-radius: 1rem;
+    padding: 1.25rem 1.5rem;
+    font-size: 0.92rem;
+    line-height: 1.7;
+  }
+
+  .article-content :global(pre.astro-code code) {
+    border: 0;
+    background: transparent;
+    padding: 0;
+    font-size: inherit;
+  }
+
+  /* Fallback for non-Shiki pre blocks */
+  .article-content :global(pre:not(.astro-code)) {
     overflow-x: auto;
     border: 1px solid var(--color-border);
     border-radius: 1rem;
@@ -396,7 +412,7 @@ const articleUrl = `${siteConfig.url}${canonicalPath}`;
     padding: 1rem;
   }
 
-  .article-content :global(pre code) {
+  .article-content :global(pre:not(.astro-code) code) {
     border: 0;
     background: transparent;
     padding: 0;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -210,6 +210,16 @@ img {
   gap: 1.4rem;
 }
 
+/* Shiki syntax highlighting — dark mode override for class-based dark theme */
+.dark .astro-code,
+.dark .astro-code span {
+  color: var(--shiki-dark) !important;
+  background-color: var(--shiki-dark-bg) !important;
+  font-style: var(--shiki-dark-font-style) !important;
+  font-weight: var(--shiki-dark-font-weight) !important;
+  text-decoration: var(--shiki-dark-text-decoration) !important;
+}
+
 /* Named view-transition layers — header/footer stay put, only main content moves */
 .site-header {
   view-transition-name: site-header;


### PR DESCRIPTION
## Summary

- **Shiki シンタックスハイライト導入**: `github-light` / `github-dark` デュアルテーマを設定。`.dark` クラスベースのダークモードに対応するCSS overrideを追加
- **ArticleLayout スタイル調整**: `pre.astro-code` 向けのborder/padding/line-heightスタイルを追加。非Shikiブロック用のfallbackも維持

## Changes

- `astro.config.mjs`: `shikiConfig` に `github-light` / `github-dark` デュアルテーマを設定
- `src/styles/global.css`: `.dark .astro-code` 向けダークモードCSS overrideを追加
- `src/layouts/ArticleLayout.astro`: `pre.astro-code` 専用スタイルを追加

## Test plan

- [ ] コードブロックでシンタックスハイライトが表示されること
- [ ] ダークモード切替でコードブロックのテーマが切り替わること
- [ ] `pnpm build` がエラーなく完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)