### PR TITLE
feat: 目次リデザイン — 番号・右下FAB・黒×オレンジ配色・記事終了フェードアウト

### DIFF
--- a/src/layouts/ArticleLayout.astro
+++ b/src/layouts/ArticleLayout.astro
@@ -138,6 +138,8 @@ const hasToc = filteredToc.length > 0;
       <slot />
     </div>
 
+    {hasToc && <div id="toc-end-sentinel" aria-hidden="true" />}
+
     {(prevArticle || nextArticle) && (
       <nav class="article-nav" aria-label="前後の記事">
         <div class="article-nav__inner">
@@ -237,6 +239,7 @@ const hasToc = filteredToc.length > 0;
   function setupToc() {
     const fab = document.getElementById("toc-fab") as HTMLButtonElement | null;
     const sentinel = document.getElementById("toc-sentinel");
+    const endSentinel = document.getElementById("toc-end-sentinel");
     const dialog = document.getElementById("toc-dialog") as HTMLDialogElement | null;
     const closeBtn = document.getElementById("toc-close");
     if (!fab || !sentinel || !dialog) return;
@@ -248,6 +251,13 @@ const hasToc = filteredToc.length > 0;
       ([e]) => fab.classList.toggle("toc-fab--visible", !e.isIntersecting),
       { rootMargin: "0px", threshold: 0 }
     ).observe(sentinel);
+
+    if (endSentinel) {
+      new IntersectionObserver(
+        ([e]) => fab.classList.toggle("toc-fab--ending", e.isIntersecting),
+        { rootMargin: "0px", threshold: 0 }
+      ).observe(endSentinel);
+    }
 
     function openToc() {
       dlg.showModal();
@@ -406,7 +416,7 @@ const hasToc = filteredToc.length > 0;
     width: 1rem;
     height: 1rem;
     flex-shrink: 0;
-    color: var(--color-text-muted);
+    color: #f97316;
   }
 
   .toc-chevron {
@@ -434,6 +444,11 @@ const hasToc = filteredToc.length > 0;
     margin: 0;
     display: flex;
     flex-direction: column;
+    counter-reset: toc-counter;
+  }
+
+  .toc-item {
+    counter-increment: toc-counter;
   }
 
   .toc-link {
@@ -448,6 +463,15 @@ const hasToc = filteredToc.length > 0;
     transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
   }
 
+  .toc-link::before {
+    content: counter(toc-counter) ".";
+    color: #f97316;
+    font-weight: 700;
+    font-size: 0.8em;
+    margin-right: 0.35rem;
+    font-variant-numeric: tabular-nums;
+  }
+
   .toc-link:hover {
     color: var(--color-text);
     background: var(--color-surface-muted);
@@ -455,7 +479,7 @@ const hasToc = filteredToc.length > 0;
   }
 
   .toc-link--active {
-    color: #f97316;
+    color: var(--color-text);
     font-weight: 600;
     border-left-color: #f97316;
     background: color-mix(in srgb, #f97316 6%, transparent);
@@ -485,21 +509,21 @@ const hasToc = filteredToc.length > 0;
   /* ── FAB ── */
   .toc-fab {
     position: fixed;
-    bottom: 1.75rem;
-    left: 50%;
+    bottom: 2rem;
+    right: 1.75rem;
     z-index: 40;
     display: flex;
     align-items: center;
-    gap: 0.4rem;
-    padding: 0.55rem 1.1rem;
+    gap: 0.5rem;
+    padding: 0.7rem 1.3rem;
     border-radius: 9999px;
-    border: 1px solid var(--color-border);
-    background: var(--color-surface);
-    color: var(--color-text-muted);
+    border: 2px solid #f97316;
+    background: #111;
+    color: #fff;
     cursor: pointer;
-    box-shadow: 0 4px 20px rgb(0 0 0 / 0.12), 0 1px 4px rgb(0 0 0 / 0.08);
+    box-shadow: 0 4px 24px rgb(0 0 0 / 0.22), 0 2px 6px rgb(249 115 22 / 0.18);
     opacity: 0;
-    transform: translateX(-50%) translateY(0.75rem);
+    transform: translateY(0.75rem);
     pointer-events: none;
     transition:
       opacity 0.25s ease,
@@ -508,27 +532,39 @@ const hasToc = filteredToc.length > 0;
       color 0.15s ease,
       border-color 0.15s ease;
     white-space: nowrap;
-    font-size: 0.85rem;
+    font-size: 0.92rem;
     font-weight: 600;
     font-family: inherit;
   }
 
   .toc-fab svg {
-    width: 1rem;
-    height: 1rem;
+    width: 1.2rem;
+    height: 1.2rem;
     flex-shrink: 0;
+    color: #f97316;
+    transition: color 0.15s ease;
   }
 
   .toc-fab--visible {
     opacity: 1;
-    transform: translateX(-50%) translateY(0);
+    transform: translateY(0);
     pointer-events: auto;
   }
 
+  .toc-fab--ending {
+    opacity: 0 !important;
+    transform: translateY(-1.5rem) !important;
+    pointer-events: none !important;
+  }
+
   .toc-fab:hover {
-    background: var(--color-surface-muted);
-    color: var(--color-text);
-    border-color: color-mix(in srgb, #f97316 50%, var(--color-border));
+    background: #f97316;
+    color: #fff;
+    border-color: #f97316;
+  }
+
+  .toc-fab:hover svg {
+    color: #fff;
   }
 
   /* ── Bottom Sheet Dialog ── */
@@ -576,7 +612,7 @@ const hasToc = filteredToc.length > 0;
   .toc-dialog__handle {
     width: 2.5rem;
     height: 4px;
-    background: var(--color-border);
+    background: #f97316;
     border-radius: 9999px;
     margin: 0.75rem auto 0;
   }
@@ -587,10 +623,10 @@ const hasToc = filteredToc.length > 0;
     justify-content: space-between;
     gap: 0.75rem;
     padding: 0.75rem 1rem;
-    border-bottom: 1px solid var(--color-border);
+    border-bottom: 1px solid #f97316;
     position: sticky;
     top: 0;
-    background: var(--color-surface);
+    background: #111;
     z-index: 1;
   }
 
@@ -600,14 +636,14 @@ const hasToc = filteredToc.length > 0;
     gap: 0.4rem;
     font-weight: 700;
     font-size: 0.9rem;
-    color: var(--color-text);
+    color: #f97316;
   }
 
   .toc-dialog__title svg {
     width: 1rem;
     height: 1rem;
     flex-shrink: 0;
-    color: var(--color-text-muted);
+    color: #f97316;
   }
 
   .toc-dialog__close {
@@ -615,9 +651,9 @@ const hasToc = filteredToc.length > 0;
     height: 1.75rem;
     padding: 0;
     border-radius: 50%;
-    border: 1px solid var(--color-border);
+    border: 1px solid #444;
     background: transparent;
-    color: var(--color-text-muted);
+    color: #aaa;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -634,13 +670,13 @@ const hasToc = filteredToc.length > 0;
   }
 
   .toc-dialog__close:hover {
-    background: var(--color-surface-muted);
-    color: var(--color-text);
+    background: rgba(255 255 255 / 0.1);
+    color: #fff;
   }
 
   .toc-dialog__body {
-    padding: 0.75rem 1rem 1.5rem;
-    padding-bottom: max(1.5rem, env(safe-area-inset-bottom));
+    padding: 0.75rem 1rem 1rem;
+    padding-bottom: max(2.75rem, env(safe-area-inset-bottom));
   }
 
   /* ── Article content ── */


### PR DESCRIPTION
## Summary

- CSS counter で各目次項目にオレンジ番号を自動付与（追加 JS ゼロ）
- FAB ボタンを左中央固定 → 右下固定に移動、padding・font・icon を拡大
- FAB・ダイアログヘッダーを黒（`#111`）× オレンジ（`#f97316`）配色に統一
- ダイアログのボトムシート下余白を `max(1.5rem…)` → `max(2.75rem…)` に増加
- 記事本文末尾に `#toc-end-sentinel` を追加し、記事読了時に FAB が上方向へフェードアウト（`translateY(-1.5rem)` + `opacity:0`）
- スクロールハイライトは既存 `IntersectionObserver` を維持、JS 追加量は最小限

## Test plan

- [ ] `pnpm check` — Biome warnings のみ（errors なし）
- [ ] `pnpm typecheck` — errors 0
- [ ] `pnpm build` — 39 pages ビルド成功
- [ ] `pnpm perf:js-budget` — 5.68 KB / 50 KB PASS
- [ ] 記事ページで目次に番号が表示されること
- [ ] FAB が右下に表示・サイズが大きくなっていること
- [ ] 記事末までスクロールすると FAB が上にフェードアウトすること
- [ ] スクロール位置に応じて目次がハイライトされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)