### PR TITLE
feat: UI Polish — TOC・ヘッダー・CTAボタン全面刷新

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "Astro Dev",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["dev"],
+      "port": 4321
+    },
+    {
+      "name": "Astro Preview",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["preview"],
+      "port": 4321
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ Thumbs.db
 .vscode/*
 !.vscode/extensions.json
 .idea/
+
+# Claude Code — ignore runtime/local files, but track launch.json
+.claude/settings.local.json
+.claude/worktrees/

--- a/src/components/LanguageSwitcher.astro
+++ b/src/components/LanguageSwitcher.astro
@@ -13,6 +13,11 @@ const targetLocale = locale === "ja" ? "en" : "ja";
 const label = locale === "ja" ? t.switchToEnglish : t.switchToJapanese;
 ---
 
-<a class="language-switcher" href={alternateHref} hreflang={targetLocale}>
-  {label}
+<a class="language-switcher" href={alternateHref} hreflang={targetLocale} aria-label={label}>
+  <svg class="lang-globe" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="10"/>
+    <line x1="2" y1="12" x2="22" y2="12"/>
+    <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
+  </svg>
+  <span class="lang-code">{targetLocale === "en" ? "EN" : "JA"}</span>
 </a>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -18,8 +18,16 @@ const t = getUi(locale);
   data-dark-label={t.dark}
   aria-label={t.theme}
 >
-  <span aria-hidden="true" data-theme-icon>◐</span>
-  <span data-theme-label>{t.theme}</span>
+  <!-- Moon: shown in light mode → click to go dark -->
+  <svg class="theme-icon theme-icon--moon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+  </svg>
+  <!-- Sun: shown in dark mode → click to go light -->
+  <svg class="theme-icon theme-icon--sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="4"/>
+    <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/>
+  </svg>
+  <span class="theme-toggle__label sr-only" data-theme-label>{t.theme}</span>
 </button>
 
 <script is:inline>
@@ -35,13 +43,8 @@ const t = getUi(locale);
 
       document.querySelectorAll("[data-theme-toggle]").forEach((button) => {
         const label = button.querySelector("[data-theme-label]");
-        const icon = button.querySelector("[data-theme-icon]");
         if (label) {
           label.textContent = theme === "dark" ? button.dataset.lightLabel : button.dataset.darkLabel;
-        }
-        if (icon) {
-          // Both modes use filled circle. Color follows text color (Black/White).
-          icon.textContent = "●";
         }
       });
     };

--- a/src/layouts/ArticleLayout.astro
+++ b/src/layouts/ArticleLayout.astro
@@ -281,38 +281,46 @@ const hasToc = filteredToc.length > 0;
     dlg.addEventListener("click", (e) => { if (e.target === dlg) closeToc(); });
     dlg.querySelectorAll("a").forEach((a) => a.addEventListener("click", closeToc));
 
-    const tocLinks = document.querySelectorAll<HTMLAnchorElement>(".toc-list a");
+    const tocLinks = Array.from(
+      document.querySelectorAll<HTMLAnchorElement>(".toc-list a")
+    );
     const headings = Array.from(
       document.querySelectorAll<HTMLElement>(".article-content h2[id], .article-content h3[id]")
     );
     if (!tocLinks.length || !headings.length) return;
 
-    // Scroll-based highlight: find last heading at or above the offset line
-    function getActiveId() {
-      const offset = 96;
-      let id = "";
+    let rafId = 0;
+    let prevActiveId = "";
+
+    function applyHighlight() {
+      rafId = 0;
+      const THRESHOLD = 100;
+      let activeId = "";
       for (const h of headings) {
-        if (h.getBoundingClientRect().top <= offset) id = h.id;
+        if (h.getBoundingClientRect().top < THRESHOLD) activeId = h.id;
         else break;
       }
-      return id;
+      if (activeId === prevActiveId) return;
+      prevActiveId = activeId;
+      for (const link of tocLinks) {
+        link.classList.toggle(
+          "toc-link--active",
+          decodeURIComponent(link.hash) === "#" + activeId
+        );
+      }
     }
 
-    let lastActiveId = "";
-    function syncHighlight() {
-      const id = getActiveId();
-      if (id === lastActiveId) return;
-      lastActiveId = id;
-      tocLinks.forEach((link) =>
-        link.classList.toggle("toc-link--active", link.hash === "#" + id)
-      );
+    function onScroll() {
+      if (rafId) return;
+      rafId = requestAnimationFrame(applyHighlight);
     }
 
-    window.addEventListener("scroll", syncHighlight, { passive: true });
-    syncHighlight();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    applyHighlight();
 
     document.addEventListener("astro:before-swap", () => {
-      window.removeEventListener("scroll", syncHighlight);
+      window.removeEventListener("scroll", onScroll);
+      cancelAnimationFrame(rafId);
     }, { once: true });
   }
 
@@ -498,7 +506,7 @@ const hasToc = filteredToc.length > 0;
     color: var(--color-text);
     font-weight: 600;
     border-left-color: #f97316;
-    background: color-mix(in srgb, #f97316 6%, transparent);
+    background: color-mix(in srgb, #f97316 8%, transparent);
   }
 
   .toc-item--2 .toc-link {
@@ -695,7 +703,7 @@ const hasToc = filteredToc.length > 0;
 
   .toc-dialog__body {
     padding: 0.75rem 1rem;
-    padding-bottom: max(4rem, env(safe-area-inset-bottom, 0px));
+    padding-bottom: calc(4rem + env(safe-area-inset-bottom, 0px));
   }
 
   /* ── Article content ── */

--- a/src/layouts/ArticleLayout.astro
+++ b/src/layouts/ArticleLayout.astro
@@ -598,7 +598,7 @@ const hasToc = filteredToc.length > 0;
   @keyframes sheet-up {
     from {
       opacity: 0;
-      transform: translateX(-50%) translateY(50%);
+      transform: translateX(-50%) translateY(calc(100% + 1.5rem));
     }
     to {
       opacity: 1;
@@ -609,20 +609,21 @@ const hasToc = filteredToc.length > 0;
   .toc-dialog {
     padding: 0;
     position: fixed;
-    bottom: 0;
+    bottom: 1.25rem;
     left: 50%;
     top: auto;
     transform: translateX(-50%);
     border: 1px solid var(--color-border);
-    border-bottom: none;
-    border-radius: 1.5rem 1.5rem 0 0;
+    border-radius: 1.5rem;
     background: var(--color-surface);
     color: var(--color-text);
-    width: min(100vw, 600px);
+    width: min(calc(100vw - 2rem), 600px);
     max-height: 70vh;
     overflow-y: auto;
     overscroll-behavior: contain;
-    box-shadow: 0 -4px 30px rgb(0 0 0 / 0.15);
+    box-shadow:
+      0 8px 40px rgb(0 0 0 / 0.22),
+      0 2px 8px rgb(0 0 0 / 0.1);
     margin: 0;
   }
 

--- a/src/layouts/ArticleLayout.astro
+++ b/src/layouts/ArticleLayout.astro
@@ -254,7 +254,13 @@ const hasToc = filteredToc.length > 0;
 
     if (endSentinel) {
       new IntersectionObserver(
-        ([e]) => fab.classList.toggle("toc-fab--ending", e.isIntersecting),
+        ([e]) => {
+          // Keep FAB hidden when at end OR when scrolled past end (sentinel above viewport)
+          fab.classList.toggle(
+            "toc-fab--ending",
+            e.isIntersecting || e.boundingClientRect.top < 0
+          );
+        },
         { rootMargin: "0px", threshold: 0 }
       ).observe(endSentinel);
     }
@@ -276,28 +282,38 @@ const hasToc = filteredToc.length > 0;
     dlg.querySelectorAll("a").forEach((a) => a.addEventListener("click", closeToc));
 
     const tocLinks = document.querySelectorAll<HTMLAnchorElement>(".toc-list a");
-    const headings = document.querySelectorAll<HTMLElement>(
-      ".article-content h2[id], .article-content h3[id]"
+    const headings = Array.from(
+      document.querySelectorAll<HTMLElement>(".article-content h2[id], .article-content h3[id]")
     );
     if (!tocLinks.length || !headings.length) return;
 
-    let activeId = "";
-    const io = new IntersectionObserver(
-      (entries) => {
-        let top: IntersectionObserverEntry | null = null;
-        for (const e of entries) {
-          if (e.isIntersecting && (!top || e.boundingClientRect.top < top.boundingClientRect.top)) {
-            top = e;
-          }
-        }
-        if (top) activeId = (top.target as HTMLElement).id;
-        tocLinks.forEach((link) =>
-          link.classList.toggle("toc-link--active", link.hash === "#" + activeId)
-        );
-      },
-      { rootMargin: "-10% 0px -80% 0px" }
-    );
-    headings.forEach((h) => io.observe(h));
+    // Scroll-based highlight: find last heading at or above the offset line
+    function getActiveId() {
+      const offset = 96;
+      let id = "";
+      for (const h of headings) {
+        if (h.getBoundingClientRect().top <= offset) id = h.id;
+        else break;
+      }
+      return id;
+    }
+
+    let lastActiveId = "";
+    function syncHighlight() {
+      const id = getActiveId();
+      if (id === lastActiveId) return;
+      lastActiveId = id;
+      tocLinks.forEach((link) =>
+        link.classList.toggle("toc-link--active", link.hash === "#" + id)
+      );
+    }
+
+    window.addEventListener("scroll", syncHighlight, { passive: true });
+    syncHighlight();
+
+    document.addEventListener("astro:before-swap", () => {
+      window.removeEventListener("scroll", syncHighlight);
+    }, { once: true });
   }
 
   document.addEventListener("astro:page-load", setupToc);
@@ -527,10 +543,10 @@ const hasToc = filteredToc.length > 0;
     pointer-events: none;
     transition:
       opacity 0.25s ease,
-      transform 0.25s ease,
-      background 0.15s ease,
-      color 0.15s ease,
-      border-color 0.15s ease;
+      transform 0.22s ease,
+      box-shadow 0.2s ease,
+      border-color 0.2s ease,
+      background 0.2s ease;
     white-space: nowrap;
     font-size: 0.92rem;
     font-weight: 600;
@@ -542,7 +558,6 @@ const hasToc = filteredToc.length > 0;
     height: 1.2rem;
     flex-shrink: 0;
     color: #f97316;
-    transition: color 0.15s ease;
   }
 
   .toc-fab--visible {
@@ -553,18 +568,22 @@ const hasToc = filteredToc.length > 0;
 
   .toc-fab--ending {
     opacity: 0 !important;
-    transform: translateY(-1.5rem) !important;
+    transform: translateY(0.5rem) !important;
     pointer-events: none !important;
   }
 
   .toc-fab:hover {
-    background: #f97316;
-    color: #fff;
-    border-color: #f97316;
+    border-color: #fb923c;
+    background: color-mix(in srgb, #111 82%, #f97316 18%);
+    box-shadow:
+      0 4px 24px rgb(0 0 0 / 0.3),
+      0 0 18px rgb(249 115 22 / 0.4),
+      0 0 36px rgb(249 115 22 / 0.18);
+    transform: translateY(-1px);
   }
 
-  .toc-fab:hover svg {
-    color: #fff;
+  .toc-fab--visible:hover {
+    transform: translateY(-1px);
   }
 
   /* ── Bottom Sheet Dialog ── */
@@ -588,7 +607,7 @@ const hasToc = filteredToc.length > 0;
     transform: translateX(-50%);
     border: 1px solid var(--color-border);
     border-bottom: none;
-    border-radius: 1.25rem 1.25rem 0 0;
+    border-radius: 1.5rem 1.5rem 0 0;
     background: var(--color-surface);
     color: var(--color-text);
     width: min(100vw, 600px);
@@ -675,8 +694,8 @@ const hasToc = filteredToc.length > 0;
   }
 
   .toc-dialog__body {
-    padding: 0.75rem 1rem 1rem;
-    padding-bottom: max(2.75rem, env(safe-area-inset-bottom));
+    padding: 0.75rem 1rem;
+    padding-bottom: max(4rem, env(safe-area-inset-bottom, 0px));
   }
 
   /* ── Article content ── */

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -173,36 +173,61 @@ const websiteJsonLd = safeJsonLd({
     margin-top: 1.5rem;
   }
 
-  .hero__cta-primary {
-    display: inline-block;
-    padding: 0.65rem 1.5rem;
-    background: var(--color-text);
-    color: var(--color-bg);
-    border-radius: 999px;
+  .hero__cta-primary,
+  .hero__cta-secondary {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.72rem 1.5rem;
+    border-radius: 0.65rem;
     font-size: 0.92rem;
-    font-weight: 600;
+    font-weight: 700;
     text-decoration: none;
-    transition: opacity 0.15s ease;
+    letter-spacing: 0.01em;
+    transition:
+      transform 0.18s ease,
+      box-shadow 0.18s ease,
+      background 0.18s ease,
+      border-color 0.18s ease,
+      color 0.18s ease;
+  }
+
+  .hero__cta-primary::after,
+  .hero__cta-secondary::after {
+    content: "→";
+    margin-left: 0.45rem;
+    display: inline-block;
+    transition: transform 0.18s ease;
+  }
+
+  .hero__cta-primary:hover::after,
+  .hero__cta-secondary:hover::after {
+    transform: translateX(4px);
+  }
+
+  .hero__cta-primary {
+    background: #f97316;
+    color: #fff;
+    box-shadow: 0 2px 16px rgb(249 115 22 / 0.28);
   }
 
   .hero__cta-primary:hover {
-    opacity: 0.8;
+    background: #fb923c;
+    color: #fff;
+    transform: translateY(-2px);
+    box-shadow: 0 6px 28px rgb(249 115 22 / 0.45);
   }
 
   .hero__cta-secondary {
-    display: inline-block;
-    padding: 0.65rem 1.5rem;
-    border: 1px solid var(--color-border);
-    border-radius: 999px;
-    font-size: 0.92rem;
-    font-weight: 600;
-    color: var(--color-text);
-    text-decoration: none;
-    transition: border-color 0.15s ease;
+    background: transparent;
+    border: 1.5px solid var(--color-border);
+    color: var(--color-text-muted);
   }
 
   .hero__cta-secondary:hover {
     border-color: var(--color-text-muted);
+    color: var(--color-text);
+    background: var(--color-surface);
+    transform: translateY(-1px);
   }
 
   .hero__profile {

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -205,14 +205,27 @@ const websiteJsonLd = safeJsonLd({
   }
 
   .hero__cta-primary {
-    background: #f97316;
-    color: #fff;
-    box-shadow: 0 2px 16px rgb(249 115 22 / 0.28);
+    background: var(--color-text);
+    color: var(--color-bg);
+    box-shadow: 0 2px 12px rgb(0 0 0 / 0.12);
   }
 
   .hero__cta-primary:hover {
+    background: var(--color-text);
+    color: var(--color-bg);
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgb(0 0 0 / 0.18);
+  }
+
+  :global(.dark) .hero__cta-primary {
+    background: #f97316;
+    color: #111;
+    box-shadow: 0 2px 16px rgb(249 115 22 / 0.28);
+  }
+
+  :global(.dark) .hero__cta-primary:hover {
     background: #fb923c;
-    color: #fff;
+    color: #111;
     transform: translateY(-2px);
     box-shadow: 0 6px 28px rgb(249 115 22 / 0.45);
   }
@@ -220,7 +233,7 @@ const websiteJsonLd = safeJsonLd({
   .hero__cta-secondary {
     background: transparent;
     border: 1.5px solid var(--color-border);
-    color: var(--color-text-muted);
+    color: var(--color-text);
   }
 
   .hero__cta-secondary:hover {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -173,36 +173,61 @@ const websiteJsonLd = safeJsonLd({
     margin-top: 1.5rem;
   }
 
-  .hero__cta-primary {
-    display: inline-block;
-    padding: 0.65rem 1.5rem;
-    background: var(--color-text);
-    color: var(--color-bg);
-    border-radius: 999px;
+  .hero__cta-primary,
+  .hero__cta-secondary {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.72rem 1.5rem;
+    border-radius: 0.65rem;
     font-size: 0.92rem;
-    font-weight: 600;
+    font-weight: 700;
     text-decoration: none;
-    transition: opacity 0.15s ease;
+    letter-spacing: 0.01em;
+    transition:
+      transform 0.18s ease,
+      box-shadow 0.18s ease,
+      background 0.18s ease,
+      border-color 0.18s ease,
+      color 0.18s ease;
+  }
+
+  .hero__cta-primary::after,
+  .hero__cta-secondary::after {
+    content: "→";
+    margin-left: 0.45rem;
+    display: inline-block;
+    transition: transform 0.18s ease;
+  }
+
+  .hero__cta-primary:hover::after,
+  .hero__cta-secondary:hover::after {
+    transform: translateX(4px);
+  }
+
+  .hero__cta-primary {
+    background: #f97316;
+    color: #fff;
+    box-shadow: 0 2px 16px rgb(249 115 22 / 0.28);
   }
 
   .hero__cta-primary:hover {
-    opacity: 0.8;
+    background: #fb923c;
+    color: #fff;
+    transform: translateY(-2px);
+    box-shadow: 0 6px 28px rgb(249 115 22 / 0.45);
   }
 
   .hero__cta-secondary {
-    display: inline-block;
-    padding: 0.65rem 1.5rem;
-    border: 1px solid var(--color-border);
-    border-radius: 999px;
-    font-size: 0.92rem;
-    font-weight: 600;
-    color: var(--color-text);
-    text-decoration: none;
-    transition: border-color 0.15s ease;
+    background: transparent;
+    border: 1.5px solid var(--color-border);
+    color: var(--color-text-muted);
   }
 
   .hero__cta-secondary:hover {
     border-color: var(--color-text-muted);
+    color: var(--color-text);
+    background: var(--color-surface);
+    transform: translateY(-1px);
   }
 
   .hero__profile {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -204,15 +204,30 @@ const websiteJsonLd = safeJsonLd({
     transform: translateX(4px);
   }
 
+  /* Light mode: dark solid button */
   .hero__cta-primary {
-    background: #f97316;
-    color: #fff;
-    box-shadow: 0 2px 16px rgb(249 115 22 / 0.28);
+    background: var(--color-text);
+    color: var(--color-bg);
+    box-shadow: 0 2px 12px rgb(0 0 0 / 0.12);
   }
 
   .hero__cta-primary:hover {
+    background: var(--color-text);
+    color: var(--color-bg);
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgb(0 0 0 / 0.18);
+  }
+
+  /* Dark mode: orange button with dark text (contrast ratio ~6.7:1) */
+  :global(.dark) .hero__cta-primary {
+    background: #f97316;
+    color: #111;
+    box-shadow: 0 2px 16px rgb(249 115 22 / 0.28);
+  }
+
+  :global(.dark) .hero__cta-primary:hover {
     background: #fb923c;
-    color: #fff;
+    color: #111;
     transform: translateY(-2px);
     box-shadow: 0 6px 28px rgb(249 115 22 / 0.45);
   }
@@ -220,7 +235,7 @@ const websiteJsonLd = safeJsonLd({
   .hero__cta-secondary {
     background: transparent;
     border: 1.5px solid var(--color-border);
-    color: var(--color-text-muted);
+    color: var(--color-text);
   }
 
   .hero__cta-secondary:hover {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -176,14 +176,26 @@ img {
 }
 
 /* Sun/moon icon visibility driven by theme class */
-.theme-icon--sun { display: none; }
-.theme-icon--moon { display: block; }
-.dark .theme-icon--sun { display: block; }
-.dark .theme-icon--moon { display: none; }
+.theme-icon--sun {
+  display: none;
+}
+.theme-icon--moon {
+  display: block;
+}
+.dark .theme-icon--sun {
+  display: block;
+}
+.dark .theme-icon--moon {
+  display: none;
+}
 
 /* Globe icon */
-.lang-globe { color: currentColor; }
-.lang-code { line-height: 1; }
+.lang-globe {
+  color: currentColor;
+}
+.lang-code {
+  line-height: 1;
+}
 
 .site-main {
   padding-block: 5.5rem;
@@ -238,10 +250,15 @@ img {
 /* Shiki syntax highlighting — dark mode override for class-based dark theme */
 .dark .astro-code,
 .dark .astro-code span {
+  /* biome-ignore lint/complexity/noImportantStyles: must override Shiki's inline styles */
   color: var(--shiki-dark) !important;
+  /* biome-ignore lint/complexity/noImportantStyles: must override Shiki's inline styles */
   background-color: var(--shiki-dark-bg) !important;
+  /* biome-ignore lint/complexity/noImportantStyles: must override Shiki's inline styles */
   font-style: var(--shiki-dark-font-style) !important;
+  /* biome-ignore lint/complexity/noImportantStyles: must override Shiki's inline styles */
   font-weight: var(--shiki-dark-font-weight) !important;
+  /* biome-ignore lint/complexity/noImportantStyles: must override Shiki's inline styles */
   text-decoration: var(--shiki-dark-text-decoration) !important;
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -82,8 +82,10 @@ img {
 }
 
 .site-header {
-  border-bottom: 1px solid var(--color-border);
-  background: var(--color-bg);
+  border-bottom: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
+  background: color-mix(in srgb, var(--color-bg) 85%, transparent);
+  backdrop-filter: blur(14px) saturate(1.5);
+  -webkit-backdrop-filter: blur(14px) saturate(1.5);
   position: sticky;
   top: 0;
   z-index: 10;
@@ -272,24 +274,47 @@ img {
 
 @media (max-width: 760px) {
   .site-header__inner {
+    flex-wrap: wrap;
     align-items: center;
-    flex-direction: column;
-    padding-block: 0.75rem;
-    gap: 0.75rem;
+    padding-block: 0.6rem;
+    gap: 0.4rem 0.75rem;
     min-height: auto;
   }
 
-  .site-header__brand-text {
-    align-items: center;
-    text-align: center;
+  .site-header__brand {
+    flex: 1;
+    min-width: 0;
   }
 
+  /* Actions visible on mobile, right of brand */
   .site-header__actions {
+    display: flex;
+    gap: 0.6rem;
+  }
+
+  /* Nav pushes to second row, full width, centered */
+  .site-header__nav {
+    order: 3;
+    flex-basis: 100%;
+    justify-content: center;
+    gap: 1.25rem;
+    padding-top: 0.4rem;
+    padding-bottom: 0.1rem;
+    border-top: 1px solid var(--color-border);
+  }
+
+  .site-header__nav a {
+    font-size: 0.82rem;
+  }
+
+  /* Author subline hidden on mobile to keep brand compact */
+  .site-header__author {
     display: none;
   }
 
+  /* Actions now in header, hide from footer on mobile */
   .site-footer__actions {
-    display: flex;
+    display: none;
   }
 
   .site-footer__inner {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -122,17 +122,13 @@ img {
   gap: 1.4rem;
 }
 
-.site-header__nav a,
-.language-switcher,
-.theme-toggle {
+.site-header__nav a {
   color: var(--color-text-muted);
   font-size: 0.92rem;
   text-decoration: none;
 }
 
-.site-header__nav a:hover,
-.language-switcher:hover,
-.theme-toggle:hover {
+.site-header__nav a:hover {
   color: var(--color-text);
 }
 
@@ -141,29 +137,51 @@ img {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.4rem;
+  gap: 0.3rem;
   border: 1px solid var(--color-border);
-  border-radius: 999px;
+  border-radius: 0.5rem;
   background: var(--color-surface);
-  padding: 0.45rem 0.72rem;
+  padding: 0.38rem 0.58rem;
   cursor: pointer;
+  color: var(--color-text-muted);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  text-decoration: none;
   transition:
-    background-color 0.2s ease,
-    border-color 0.2s ease,
-    box-shadow 0.2s ease;
-  box-shadow: var(--shadow-soft);
+    color 0.15s ease,
+    border-color 0.15s ease,
+    box-shadow 0.15s ease,
+    background 0.15s ease;
 }
 
-.theme-toggle {
-  width: 6.6rem; /* Slightly narrower but still fixed to prevent shifts */
+.theme-toggle svg,
+.language-switcher svg {
+  width: 0.9rem;
+  height: 0.9rem;
+  flex-shrink: 0;
 }
 
 .theme-toggle:hover,
 .language-switcher:hover {
-  background: color-mix(in srgb, var(--color-surface) 90%, var(--color-link) 10%);
-  border-color: var(--color-link);
-  box-shadow: 0 8px 24px rgb(28 27 24 / 0.12);
+  color: var(--color-text);
+  border-color: #f97316;
+  background: color-mix(in srgb, var(--color-surface) 94%, #f97316 6%);
+  box-shadow:
+    0 0 0 3px color-mix(in srgb, transparent 87%, #f97316 13%),
+    0 2px 10px rgb(249 115 22 / 0.1);
 }
+
+/* Sun/moon icon visibility driven by theme class */
+.theme-icon--sun { display: none; }
+.theme-icon--moon { display: block; }
+.dark .theme-icon--sun { display: block; }
+.dark .theme-icon--moon { display: none; }
+
+/* Globe icon */
+.lang-globe { color: currentColor; }
+.lang-code { line-height: 1; }
 
 .site-main {
   padding-block: 5.5rem;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -292,19 +292,19 @@ img {
     gap: 0.6rem;
   }
 
-  /* Nav pushes to second row, full width, centered */
+  /* Nav pushes to second row, full width, left-aligned */
   .site-header__nav {
     order: 3;
     flex-basis: 100%;
-    justify-content: center;
-    gap: 1.25rem;
-    padding-top: 0.4rem;
-    padding-bottom: 0.1rem;
+    justify-content: flex-start;
+    gap: 1.5rem;
+    padding-top: 0.5rem;
+    padding-bottom: 0.15rem;
     border-top: 1px solid var(--color-border);
   }
 
   .site-header__nav a {
-    font-size: 0.82rem;
+    font-size: 0.88rem;
   }
 
   /* Author subline hidden on mobile to keep brand compact */


### PR DESCRIPTION
## Summary

- **TOC FAB 再表示バグ修正**: スクロール終端を通過後も FAB が再出現しないよう `boundingClientRect.top < 0` で「通過済み」を判定
- **TOC ハイライト修正**: IntersectionObserver → スクロールイベント + `requestAnimationFrame` 方式に変更、日本語 slug の URL エンコード不一致を `decodeURIComponent(link.hash)` で解消
- **TOC ダイアログ浮き**: `bottom: 0` → `bottom: 1.25rem`・全角丸 `1.5rem`・影強化でフローティングシート化
- **言語/テーマ切替ボタン**: テキスト → SVGアイコン化(月/太陽・グローブ)、コンパクト角丸ボタン + hover 時オレンジグロー
- **FAB hover**: 全塗り潰しオレンジ → box-shadow グロー（輝き感）
- **CTA ボタン**: ライトモードは黒ソリッド・ダークモードはオレンジ + 黒文字(コントラスト比 6.7:1)で差別化、`→` 矢印スライドアニメーション
- **ヘッダー**: `backdrop-filter: blur(14px) saturate(1.5)` でガラス質感
- **モバイルヘッダー**: `flex-wrap` CSS のみで「1行目: ブランド＋アクション / 2行目: ナビ左揃え」の2段レイアウト（JS追加なし）

## Test plan

- [ ] ダーク/ライト両モードでトップページの CTA ボタン外観・コントラストを確認
- [ ] モバイル幅(375px)でヘッダー2段レイアウトを確認
- [ ] 記事ページで目次ハイライトがスクロールに追従することを確認
- [ ] 記事の最後までスクロールしても FAB が再出現しないことを確認
- [ ] FAB タップで目次ダイアログが画面底から浮いた状態で表示されることを確認
- [ ] `pnpm build` がエラーなく完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)