### PR TITLE
feat: ハンバーガーメニューをCSSチェックボックスから最小JSへ移行

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -27,8 +27,14 @@ const t = getUi(locale);
       <span class="site-header__author">{siteConfig.author}</span>
     </a>
 
-    <input type="checkbox" class="site-nav__toggle-input sr-only" id="site-nav-toggle" aria-label={t.menu} />
-    <label class="site-nav__toggle" for="site-nav-toggle" aria-hidden="true">
+    <button
+      type="button"
+      class="site-nav__toggle"
+      id="site-nav-toggle"
+      aria-label={t.menu}
+      aria-controls="site-nav"
+      aria-expanded="false"
+    >
       <svg class="site-nav__icon site-nav__icon--open" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true">
         <line x1="3" y1="6" x2="21" y2="6"/>
         <line x1="3" y1="12" x2="21" y2="12"/>
@@ -38,8 +44,8 @@ const t = getUi(locale);
         <line x1="18" y1="6" x2="6" y2="18"/>
         <line x1="6" y1="6" x2="18" y2="18"/>
       </svg>
-    </label>
-    <nav class="site-header__nav" aria-label="Primary navigation">
+    </button>
+    <nav id="site-nav" class="site-header__nav" aria-label="Primary navigation">
       <a href={getHomePath(locale)} data-astro-prefetch>{t.home}</a>
       <a href={getArticlesPath(locale)} data-astro-prefetch>{t.articles}</a>
       <a href={getWorksPath(locale)} data-astro-prefetch>{t.works}</a>
@@ -52,6 +58,56 @@ const t = getUi(locale);
     </div>
   </div>
 </header>
+
+<script is:inline>
+  (() => {
+    const init = () => {
+      const toggle = document.getElementById("site-nav-toggle");
+      const nav = document.getElementById("site-nav");
+      if (!toggle || !nav) return;
+
+      const setOpen = (open) => toggle.setAttribute("aria-expanded", String(open));
+
+      // .onclick assignment is idempotent, so re-running init on View
+      // Transitions never stacks duplicate handlers.
+      toggle.onclick = () =>
+        setOpen(toggle.getAttribute("aria-expanded") !== "true");
+
+      // Close once a destination is chosen
+      nav.onclick = (event) => {
+        if (event.target.closest("a")) setOpen(false);
+      };
+    };
+
+    init();
+
+    // Document-level listeners are registered once and look the elements up
+    // lazily, so they keep working after each page swap replaces the header.
+    if (!window.__siteNavListenerAdded) {
+      window.__siteNavListenerAdded = true;
+
+      const close = () =>
+        document
+          .getElementById("site-nav-toggle")
+          ?.setAttribute("aria-expanded", "false");
+
+      document.addEventListener("keydown", (event) => {
+        if (event.key === "Escape") close();
+      });
+
+      document.addEventListener("click", (event) => {
+        const toggle = document.getElementById("site-nav-toggle");
+        const nav = document.getElementById("site-nav");
+        if (!toggle || !nav) return;
+        if (!toggle.contains(event.target) && !nav.contains(event.target)) {
+          close();
+        }
+      });
+
+      document.addEventListener("astro:after-swap", init);
+    }
+  })();
+</script>
 
 <style>
   .site-header__brand {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -140,7 +140,8 @@ img {
 
 /* Theme toggle, language switcher and the hamburger toggle share one icon-button
    style so all three line up in size. The hamburger is hidden on desktop and
-   revealed (via a CSS-only checkbox) under 760px — see the media query below. */
+   revealed under 760px, where a minimal script toggles its aria-expanded
+   state — see the media query below. */
 .theme-toggle,
 .language-switcher,
 .site-nav__toggle {
@@ -177,7 +178,7 @@ img {
 .theme-toggle:hover,
 .language-switcher:hover,
 .site-nav__toggle:hover,
-.site-nav__toggle-input:focus-visible ~ .site-nav__toggle {
+.site-nav__toggle:focus-visible {
   color: var(--color-accent);
   border-color: var(--color-accent);
   background: color-mix(in srgb, var(--color-surface) 94%, #f97316 6%);
@@ -186,9 +187,8 @@ img {
     0 2px 10px rgb(249 115 22 / 0.1);
 }
 
-/* Hamburger + its checkbox are desktop-hidden; the media query re-enables them */
-.site-nav__toggle,
-.site-nav__toggle-input {
+/* Hamburger is desktop-hidden; the media query re-enables it */
+.site-nav__toggle {
   display: none;
 }
 
@@ -327,11 +327,6 @@ img {
     min-width: 0;
   }
 
-  /* Re-enable the checkbox (kept visually hidden but focusable) on mobile */
-  .site-nav__toggle-input {
-    display: block;
-  }
-
   /* Actions sit left of the hamburger */
   .site-header__actions {
     order: 2;
@@ -349,11 +344,11 @@ img {
     display: none;
   }
 
-  .site-nav__toggle-input:checked ~ .site-nav__toggle .site-nav__icon--open {
+  .site-nav__toggle[aria-expanded="true"] .site-nav__icon--open {
     display: none;
   }
 
-  .site-nav__toggle-input:checked ~ .site-nav__toggle .site-nav__icon--close {
+  .site-nav__toggle[aria-expanded="true"] .site-nav__icon--close {
     display: block;
   }
 
@@ -382,7 +377,7 @@ img {
       visibility 0.18s ease;
   }
 
-  .site-nav__toggle-input:checked ~ .site-header__nav {
+  .site-nav__toggle[aria-expanded="true"] ~ .site-header__nav {
     visibility: visible;
     opacity: 1;
     transform: translateY(0);


### PR DESCRIPTION
## 概要
ヘッダーのハンバーガーメニューを、CSSチェックボックスハック(`<input type="checkbox">` + `<label>`)から最小JSによる方式へ移行しました。

## 変更内容
### `src/components/Header.astro`
- `<input type="checkbox">` + `<label>` を `<button aria-expanded aria-controls="site-nav">` に置き換え
- `<nav>` に `id="site-nav"` を付与して `aria-controls` と紐付け
- 最小の `is:inline` スクリプトで `aria-expanded` をトグル。`ThemeToggle.astro` と同じく `astro:after-swap` で再初期化し、View Transitions(`ClientRouter`)後もハンドラが効くように。リスナー重複も同手法で防止

### `src/styles/global.css`
- セレクタを `.site-nav__toggle-input:checked ~ ...` → `.site-nav__toggle[aria-expanded="true"] ~ ...` に変更
- `focus-visible` をボタン本体へ移動、チェックボックス用ルールを削除

## チェックボックス方式より良くなった点
- ボタン + `aria-expanded` で本来のセマンティクス/アクセシビリティに(hidden checkbox ハックを排除)
- **Escapeキーで閉じる** / **メニュー外クリックで閉じる** / **ナビリンク選択で閉じる** を追加

## 検証
- `pnpm build`: ✅ 45ページ正常ビルド
- `pnpm perf:js-budget`: ✅ gzip 合計 5.68KB / 50KB(`is:inline` のため新規バンドル増なし)
- 動作確認(dev + DOMイベント検証): 初期=閉、開くとアイコン切替・nav表示、外側クリック/リンククリック/Escapeで閉、いずれも正常。コンソールエラーなし

## 影響
- セマンティックHTML: 改善(checkboxハック→button)
- アクセシビリティ: 改善(`aria-expanded`/`aria-controls`、Escape対応)
- SEO/パフォーマンス: 影響なし(JS予算内、静的構成維持)

🤖 Generated with [Claude Code](https://claude.com/claude-code)